### PR TITLE
Add bracket update hotkeys

### DIFF
--- a/src/Settings/TSHSettingsWindow.py
+++ b/src/Settings/TSHSettingsWindow.py
@@ -154,6 +154,8 @@ class TSHSettingsWindow(QDialog):
             "team2_score_down": QApplication.translate("settings.hotkeys", "Team 2 score down"),
             "reset_scores": QApplication.translate("settings.hotkeys", "Reset scores"),
             "swap_teams": QApplication.translate("settings.hotkeys", "Swap teams"),
+            "refresh_phase_group": QApplication.translate("settings.hotkeys", "Refresh bracket phase groups"),
+            "limit_export": QApplication.translate("settings.hotkeys", "Toggle bracket limit export"),
         }
 
         for i, (setting, value) in enumerate(TSHHotkeys.instance.keys.items()):

--- a/src/TSHBracketWidget.py
+++ b/src/TSHBracketWidget.py
@@ -13,6 +13,7 @@ from .TSHPlayerListSlotWidget import TSHPlayerListSlotWidget
 from .TSHBracketView import TSHBracketView
 from .TSHPlayerList import TSHPlayerList
 from .TSHBracket import *
+from .TSHHotkeys import TSHHotkeys
 import traceback
 from loguru import logger
 
@@ -123,6 +124,7 @@ class TSHBracketWidget(QDockWidget):
         updateIcon = QImage("./assets/icons/undo.svg").scaled(24, 24)
         self.btRefreshPhaseGroup.setIcon(QIcon(QPixmap.fromImage(updateIcon)))
         self.btRefreshPhaseGroup.clicked.connect(self.PhaseGroupChanged)
+        TSHHotkeys.signals.refresh_phase_group.connect(self.PhaseGroupChanged)
 
         self.progressionsIn: QSpinBox = self.findChild(
             QSpinBox, "progressionsIn")
@@ -176,6 +178,7 @@ class TSHBracketWidget(QDockWidget):
             ),
             self.bracketView.Update()
         ])
+        TSHHotkeys.signals.limit_export.connect(lambda: self.limitExport.setChecked(not self.limitExport.isChecked()))
 
         self.limitExportNumber: QSpinBox = self.findChild(
             QSpinBox, "limitExportNumber")

--- a/src/TSHHotkeys.py
+++ b/src/TSHHotkeys.py
@@ -22,6 +22,8 @@ class TSHHotkeysSignals(QObject):
     reset_scores = Signal()
     load_set = Signal()
     swap_teams = Signal()
+    refresh_phase_group = Signal()
+    limit_export = Signal()
 
 class TSHHotkeys(QObject):
     instance: "TSHHotkeys" = None
@@ -36,7 +38,9 @@ class TSHHotkeys(QObject):
         "team2_score_up": "Ctrl+F3",
         "team2_score_down": "Ctrl+F4",
         "reset_scores": "Ctrl+R",
-        "swap_teams": "Ctrl+S"
+        "swap_teams": "Ctrl+S",
+        "refresh_phase_group": "Ctrl+P",
+        "limit_export": "Ctrl+B",
     }
 
     loaded_keys = {}


### PR DESCRIPTION
Added 2 new hotkeys that hook into existing UI functionality in the bracket widget to allow easy fetching of updated bracket information outside of the bracket widget:

- "Refresh bracket phase groups" has the same functionality as the refresh button, calling `self.PhaseGroupChanged`
- "Toggle bracket limit export" directly toggles the state of the check box