### PR TITLE
Connected score wheel to individual game tracker and vice-versa

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -1215,8 +1215,15 @@ class TSHScoreboardWidget(QWidget):
         old_value = StateManager.Get(f"score.{self.scoreboardNumber}.team.{team+1}.score")
         StateManager.Set(f"score.{self.scoreboardNumber}.team.{team+1}.score", value)
 
+        # Disable individual game tracker logic if ties were reported
+        has_ties = False
+        game_data = StateManager.Get(f"score.{self.scoreboardNumber}.stages")
+        for key in game_data.keys():
+            if game_data[key].get("tie"):
+                has_ties = True
+
         # Game tracker logic for incremental changes
-        if old_value is not None:
+        if old_value is not None and not has_ties:
             old_value = int(old_value)
             if int(value) - old_value == 1:
                 if team == 0:


### PR DESCRIPTION
- Added a feature where 1 unit increments of scores affect the individual game tracker
  - If the score is increased by 1, the winner will be reported for the game which was just reported
  - If the score is decreased by 1, the individual game tracker will reset wins for the game whcih was just un-reported
  - This logic is disabled if ties were reported
- Added a feature where manually adding game data in the individual game tracker syncs the score with the score display
  - Ties are not considered as wins for either team
- Individual game score no longer resets when selecting a new stage