### PR TITLE
StartGGDataProvider threading rework

### DIFF
--- a/src/Helpers/TSHQtHelper.py
+++ b/src/Helpers/TSHQtHelper.py
@@ -1,0 +1,40 @@
+from qtpy.QtCore import *
+
+
+def invokeSlot(meth, *args):
+    """
+    This will invoke a QObject's slot using the auto connection type, in the same
+    way that it would be triggered from a signal. The auto connection type will either:
+
+    - execute immediately if we are in the QObject's native thread.
+    - be queued for execution if we are in a different thread.
+
+    This lets us call other methods in a thread-safe way without having to bother with connecting
+    a signal and cleaning it up. WARNING: If the invocation is queued, the effects of the invoked method
+    may or may not be applied at any given time and if the caller is expecting this function
+    to execute immediately there will likely be a race condition.
+
+    Here is an example of a concrete call to invokeMethod() that this function constructs::
+
+        QMetaObject.invokeMethod(self.tshTdp, 'SetTournament',
+            Q_ARG(str, "https://start.gg/"+deep_get(userSet, "event.slug"))
+        )
+
+    :param meth: The bound object method to call via slot mechanism
+    :param args: The function arguments to pass in.
+    """
+    obj = getattr(meth, '__self__', None)
+    meth_name = getattr(meth, '__name__', None)
+
+    if not obj:
+        raise ValueError(f"The provided method {meth} does not have a bound object instance.")
+
+    if not meth_name:
+        raise ValueError(f"The provided method {meth} does not have a __name__")
+
+    QMetaObject.invokeMethod(
+        obj,
+        meth_name,
+        *(Q_ARG(type(arg), arg) for arg in args)
+    )
+

--- a/src/TSHTournamentDataProvider.py
+++ b/src/TSHTournamentDataProvider.py
@@ -31,10 +31,11 @@ class TSHTournamentDataProviderSignals(QObject):
     tournament_url_update = Signal(str)
 
 
-class TSHTournamentDataProvider:
+class TSHTournamentDataProvider(QObject):
     instance: "TSHTournamentDataProvider" = None
 
     def __init__(self) -> None:
+        super().__init__(None)
         self.provider: TournamentDataProvider = None
         self.signals: TSHTournamentDataProviderSignals = TSHTournamentDataProviderSignals()
         self.entrantsModel: QStandardItemModel = None
@@ -65,6 +66,8 @@ class TSHTournamentDataProvider:
         else:
             logger.error("Unsupported provider...")
 
+    @Slot(str, bool)
+    @Slot(str)
     def SetTournament(self, url, initialLoading=False):
         if self.provider and self.provider.url == url:
             return

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -1,6 +1,5 @@
 from collections import Counter
 import re
-from qtpy.QtCore import *
 import requests
 import os
 import traceback
@@ -8,6 +7,7 @@ from loguru import logger
 from ..Helpers.TSHCountryHelper import TSHCountryHelper
 from ..Helpers.TSHDictHelper import deep_get
 from ..Helpers.TSHDirHelper import TSHResolve
+from ..Helpers.TSHQtHelper import invokeSlot
 from ..TSHGameAssetManager import TSHGameAssetManager
 from ..TSHPlayerDB import TSHPlayerDB
 from .TournamentDataProvider import TournamentDataProvider
@@ -37,15 +37,13 @@ class StartGGDataProvider(TournamentDataProvider):
     TournamentPhaseGroupQuery = None
     TournamentStandingsQuery = None
     UserSetQuery = None
+    _request_timeout_secs = 20.0
 
     player_seeds = {}
 
-    def __init__(self, url, threadpool, parent) -> None:
-        super().__init__(url, threadpool, parent)
+    def __init__(self, url, threadpool, tshTdp) -> None:
+        super().__init__(url, threadpool, tshTdp)
         self.name = "StartGG"
-        self.getMatchThreadPool = QThreadPool()
-        self.getRecentSetsThreadPool = QThreadPool()
-        self.getStationMatchesThreadPool = QThreadPool()
 
     # Queries the provided URL until a proper 200 status code has been provided back
     #
@@ -63,6 +61,7 @@ class StartGGDataProvider(TournamentDataProvider):
             while requestCode != 200 and retries < 5:
                 data = type(
                     url,
+                    timeout=self._request_timeout_secs,
                     headers=headers,
                     json=jsonParams,
                     params=params
@@ -94,7 +93,7 @@ class StartGGDataProvider(TournamentDataProvider):
             videogame = deep_get(data, "data.event.videogame.id", None)
             if videogame:
                 self.videogame = videogame
-                self.parent.signals.game_changed.emit(videogame)
+                self.tshTdp.signals.game_changed.emit(videogame)
 
             finalData["tournamentName"] = deep_get(
                 data, "data.event.tournament.name", "")
@@ -331,12 +330,10 @@ class StartGGDataProvider(TournamentDataProvider):
 
         return finalData
 
-    def GetMatch(self, setId, progress_callback, cancel_event):
+    def GetMatch(self, setId, progress_callback=None, cancel_event=None):
         finalResult = None
 
         try:
-            pool = self.getMatchThreadPool
-
             result = {}
 
             fetchOld = Worker(self._GetMatchTasks, **{
@@ -344,29 +341,26 @@ class StartGGDataProvider(TournamentDataProvider):
                 "cancel_event": None,
                 "setId": setId
             })
-            fetchOld.signals.result.connect(
-                lambda value: result.update({"old": value}))
-            pool.start(fetchOld)
-
             fetchNew = Worker(self._GetMatchNewApi, **{
                 "progress_callback": None,
                 "cancel_event": None,
                 "setId": setId
             })
-            fetchNew.signals.result.connect(
-                lambda value: result.update({"new": value}))
-            pool.start(fetchNew)
+            self.threadpool.start(fetchOld)
+            self.threadpool.start(fetchNew)
 
-            pool.waitForDone(5000)
-            QCoreApplication.processEvents()
+            Worker.wait_for_all([fetchOld, fetchNew], self._request_timeout_secs)
+
+            result.update({"new": fetchNew.result if fetchNew.completed else {}})
+            result.update({"old": fetchOld.result if fetchOld.completed else {}})
 
             logger.debug(result)
 
             finalResult = {}
-            finalResult.update(result.get("new", {}))
-            finalResult.update(result.get("old", {}))
+            finalResult.update(result["new"])
+            finalResult.update(result["old"])
 
-            winnerProgression = result.get("old", {}).get("winnerProgression")
+            winnerProgression = result["old"].get("winnerProgression", None)
             if winnerProgression:
                 indicator = "qualifier_winners_indicator"
 
@@ -1278,8 +1272,9 @@ class StartGGDataProvider(TournamentDataProvider):
             if sets and len(sets) > 0:
                 userSet = sets[0]
 
-                self.parent.SetTournament(
-                    "https://start.gg/"+deep_get(userSet, "event.slug"))
+                # This calls the slot using the queued execution mechanism without having to worry about signals.
+                # Do this because it means that SetTournament will always run in tshTdp's native thread.
+                invokeSlot(self.tshTdp.SetTournament, "https://start.gg/"+deep_get(userSet, "event.slug"))
 
                 playerId = deep_get(data, "data.user.player.id")
                 slots = userSet.get("slots", [])
@@ -1543,15 +1538,12 @@ class StartGGDataProvider(TournamentDataProvider):
             id1 = [str(id1[0]), str(id1[1])]
             id2 = [str(id2[0]), str(id2[1])]
 
-            pool = self.getRecentSetsThreadPool
-
             recentSets = []
-
-            pool.clear()
 
             logger.info("Get recent sets start")
 
             for _id1, _id2, inverted in [[id1, id2, False], [id2, id1, True]]:
+                workers = []
                 for i in range(5):
                     worker = Worker(self.GetRecentSetsWorker, **{
                         "id1": _id1,
@@ -1560,13 +1552,15 @@ class StartGGDataProvider(TournamentDataProvider):
                         "inverted": inverted,
                         "videogame": videogame
                     })
-                    worker.signals.result.connect(lambda result: [
-                        recentSets.extend(result)
-                    ])
-                    pool.start(worker)
+                    workers.append(worker)
+                    self.threadpool.start(worker)
 
-            pool.waitForDone(20000)
-            QCoreApplication.processEvents()
+            Worker.wait_for_all(workers)
+
+            for worker in workers:
+                if worker.result is not None:
+                    recentSets.extend(worker.result)
+
             byId = {_set.get("id"): _set for _set in recentSets}
             recentSets = list(byId.values())
             recentSets.sort(key=lambda s: s.get("timestamp"), reverse=True)
@@ -1913,6 +1907,7 @@ class StartGGDataProvider(TournamentDataProvider):
         sets = []
         pool = self.getStationMatchesThreadPool
         i = 0
+        workers = []
         for set in setsId:
             sets.append(None)
             worker = Worker(self.GetMatchAndInsertInList, **{
@@ -1920,13 +1915,12 @@ class StartGGDataProvider(TournamentDataProvider):
                 "list": sets,
                 "i": i
             })
-
+            workers.append(worker)
             pool.start(worker)
 
             i += 1
 
-        pool.waitForDone(5000)
-        QCoreApplication.processEvents()
+        Worker.wait_for_all(workers, self._request_timeout_secs)
 
         sets_ = {}
         for index, set in enumerate(sets):

--- a/src/TournamentDataProvider/TournamentDataProvider.py
+++ b/src/TournamentDataProvider/TournamentDataProvider.py
@@ -4,16 +4,20 @@ from loguru import logger
 import random
 from urllib.parse import quote as urlencode
 
+from qtpy.QtCore import QObject
 
-class TournamentDataProvider:
-    def __init__(self, url, threadpool, parent) -> None:
+
+class TournamentDataProvider(QObject):
+    def __init__(self, url, threadpool, tshTdp) -> None:
+        super().__init__(None)
+
         self.name = ""
         self.url = url
         self.entrants = []
         self.tournamentData = {}
         self.threadpool = threadpool
         self.videogame = None
-        self.parent = parent
+        self.tshTdp = tshTdp
 
     def GetIconURL(self):
         pass

--- a/src/Workers.py
+++ b/src/Workers.py
@@ -1,6 +1,10 @@
+
 from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
+
+from datetime import datetime
+import time
 import traceback
 import sys
 from loguru import logger
@@ -62,6 +66,9 @@ class Worker(QRunnable):
         self.cancel_event = threading.Event()
         self.kwargs['cancel_event'] = self.cancel_event
 
+        self.completed = False
+        self.result = None
+
     @Slot()
     def run(self):
         '''
@@ -70,20 +77,48 @@ class Worker(QRunnable):
 
         # Retrieve args/kwargs here; and fire processing using them
         try:
-            result = self.fn(*self.args, **self.kwargs)
+            self.result = self.fn(*self.args, **self.kwargs)
         except Exception as e:
             logger.error(traceback.format_exc())
             exctype, value = sys.exc_info()[:2]
             self.signals.error.emit((exctype, value, traceback.format_exc()))
         else:
             # Return the result of the processing
-            self.signals.result.emit(result)
+            self.signals.result.emit(self.result)
         finally:
             if self.signals.finished:
                 self.signals.finished.emit()  # Done
+
+            # self.completed is guaranteed to not cause a race condition self.result if checked first.
+            self.completed = True
 
     def cancel(self):
         '''
         Set the cancel event to indicate that the task should be cancelled.
         '''
         self.cancel_event.set()
+
+    @staticmethod
+    def wait_for_all(workers, timeout=None):
+        """
+        Wait for a collection of workers to complete.
+
+        :returns: True if the workers complete, false if a timeout is set and exceeded.
+        """
+
+        start_time = datetime.now()
+
+        def is_timed_out():
+            nonlocal start_time
+            if timeout is None:
+                return False
+            else:
+                return (datetime.now() - start_time).total_seconds() > timeout
+
+        while not is_timed_out():
+            if all(w.completed for w in workers):
+                return True
+
+            time.sleep(0.1)
+
+        return False


### PR DESCRIPTION
Rework the threading within the startgg data provider to not use qt events.

I added a result object to our Worker abstraction so that it can be used in a futures-like way. This allows us to avoid calling processEvents in our worker threads that was causing crashes. I also did some slight cleanup around the arguments to the TDP and unified the usage of threadpools. Unifying the threadpools was made possible since we're awaiting the completion of the workers we create, rather than waiting on the whole threadpool. Common advice for threadpools in qt in general is to only have one master one, so I felt unifying the pools for different requests in this specific context was warranted.