### PR TITLE
Fix shell scripts to be cwd-independent and a few other issues

### DIFF
--- a/TSH.sh
+++ b/TSH.sh
@@ -1,11 +1,39 @@
 #!/bin/bash
 
+# The following stub makes it so that this script always runs in the directory it is located within.
+# It works on macos, and will follow symbolic links and generally will make it difficult to have
+
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+
+
+if ! pushd "${DIR}" >/dev/null 2>&1; then
+  echo "Couldn't enter directory ${DIR}. Quitting."
+  exit 255
+fi
+
+# If pip isn't in the host python, it won't be in the venv. This shows up
+# for example in ubuntu system-packaged python where `python3` is installed but not
+# `python3-dev`
+echo "Checking pip version for host python... "
+if ! python3.14 -m pip --version; then
+  echo "Failed to find pip. Quitting."
+  exit 255
+fi
+
 # Python 3.14 install instructions for Ubuntu 22.04 LTS
 #sudo add-apt-repository ppa:deadsnakes/ppa
 #sudo apt update
 #sudo apt install python3.14-dev
 
-python3.14 -m venv ./venv
-./venv/bin/pip3 install --upgrade pip
+python3.14 -m venv --upgrade-deps ./venv
 MSGPACK_PUREPYTHON=1 ./venv/bin/pip3 install -r dependencies/requirements.txt
+
 ./venv/bin/python3.14 main.py
+popd "${DIR}" >/dev/null 2>&1

--- a/main.py
+++ b/main.py
@@ -7,34 +7,8 @@ import signal
 import sys
 import os
 import asyncio
-from qasync import run, QEventLoop
-from functools import partial
+from qasync import QEventLoop
 os.environ["QT_API"] = "PyQt6"
-
-
-async def main(event_loop):
-    def close_future(future, loop):
-        loop.call_later(10, future.cancel)
-        future.cancel()
-
-    future = asyncio.Future()
-
-    window = src.Window(event_loop)
-    if hasattr(src.App, "aboutToQuit"):
-        getattr(src.App, "aboutToQuit").connect(
-            partial(close_future, future, event_loop))
-
-    try:
-        event_loop.add_signal_handler(signal.SIGINT, lambda: window.close())
-        event_loop.add_signal_handler(signal.SIGTERM, lambda: window.close())
-    except NotImplementedError:  # windows...
-        pass
-
-    await future
-    if isinstance(future.result(), int):
-        return future.result()
-
-    return 0
 
 
 if __name__ == '__main__':
@@ -42,12 +16,19 @@ if __name__ == '__main__':
     multiprocessing.freeze_support()
 
     try:
+        loop = QEventLoop(src.App)
+        asyncio.set_event_loop(loop)
+        window = src.Window(loop)
         try:
-            loop = QEventLoop()
-            asyncio.set_event_loop(loop)
-            sys.exit(loop.run_until_complete(main(loop)))
-        except asyncio.exceptions.CancelledError:
-            sys.exit(0)
+            loop.add_signal_handler(signal.SIGINT, lambda: window.close())
+            loop.add_signal_handler(signal.SIGTERM, lambda: window.close())
+        except NotImplementedError:  # windows...
+            pass
+
+        # QApplication.exec() will block until the application is closed.
+        sys.exit(src.App.exec())
+    except asyncio.exceptions.CancelledError:
+        sys.exit(255)
     except RuntimeError:
-        sys.exit(0)
+        sys.exit(255)
 

--- a/main.py
+++ b/main.py
@@ -25,8 +25,13 @@ if __name__ == '__main__':
         except NotImplementedError:  # windows...
             pass
 
-        # QApplication.exec() will block until the application is closed.
-        sys.exit(src.App.exec())
+        # To run synchronously, you would do something like the following:
+        # sys.exit(src.App.exec())
+
+        # Since this is a QEventLoop, afaik it will run App.exec() in the background.
+        with loop:
+            loop.run_forever()
+
     except asyncio.exceptions.CancelledError:
         sys.exit(255)
     except RuntimeError:

--- a/scripts/gen_release.sh
+++ b/scripts/gen_release.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 
-pushd .. > /dev/null
+# The following stub makes it so that this script always runs in the directory it is located within.
+# It works on macos, and will follow symbolic links and generally will make it difficult to have
+
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+
+
+if ! pushd "${DIR}/.." >/dev/null 2>&1; then
+  echo "Couldn't enter directory ${DIR}/.. Quitting."
+  popd >/dev/null 2>&1
+  exit 255
+fi
+
 
 # Create TSH dir and its stage_strike_app folders
 mkdir -p TournamentStreamHelper/stage_strike_app/build
@@ -25,4 +43,4 @@ zip -rv release-windows.zip TournamentStreamHelper
 
 rm -rf TournamentStreamHelper
 
-popd > /dev/null
+popd >/dev/null 2>&1

--- a/src/Settings/TSHSettingsWindow.py
+++ b/src/Settings/TSHSettingsWindow.py
@@ -43,7 +43,7 @@ class TSHSettingsWindow(QDialog):
                 "settings.general", "Webserver Port"),
             "webserver_port",
             "spinbox",
-            5000
+            5500
         ))
 
         generalSettings.append((

--- a/src/TSHScoreboardStageWidget.py
+++ b/src/TSHScoreboardStageWidget.py
@@ -125,7 +125,7 @@ class TSHScoreboardStageWidget(QDockWidget):
 
         self.webappLabel = self.findChild(QLabel, "labelIp")
         self.webappLabel.setText(
-            QApplication.translate("app", "Open {0} in a browser to stage strike.").format(f"<a href='http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5000)}'>http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5000)}</a>"))
+            QApplication.translate("app", "Open {0} in a browser to stage strike.").format(f"<a href='http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5500)}'>http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5500)}</a>"))
         self.webappLabel.setOpenExternalLinks(True)
 
         self.labelValidation = self.findChild(QLabel, "labelValidation")

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -315,7 +315,7 @@ class TSHScoreboardWidget(QWidget):
 
         self.remoteScoreboardLabel = QApplication.translate(
                 "app", "Open {0} in a browser to edit the scoreboard remotely."
-            ).format(f"<a href='http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5000)}/scoreboard'>http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5000)}/scoreboard</a>")
+            ).format(f"<a href='http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5500)}/scoreboard'>http://{self.GetIP()}:{SettingsManager.Get('general.webserver_port', 5500)}/scoreboard</a>")
         self.remoteScoreboardLabel = add_beta_label(self.remoteScoreboardLabel, "web_score")
         self.remoteScoreboardLabel = QLabel(self.remoteScoreboardLabel)
 

--- a/stage_strike_app/src/env.js
+++ b/stage_strike_app/src/env.js
@@ -1,6 +1,6 @@
 export const BACKEND_PORT = process.env.NODE_ENV === 'production'
     ? window.location.port
-    : 5000;
+    : 5500;
 
 export const BASE_URL = `http://${window.location.hostname}:${BACKEND_PORT}`
 


### PR DESCRIPTION
Also fixes:
 - qasync crashing when the program exits due to a hanging future. This was fixed by invoking src.App.exec() on the main thread, which is what is typically done in all qt gui programs, afaik.
 - Switch the default webserver port away from 5000, which is used by the macos airplay receiver, which will cause crashes on osx by default.