### PR TITLE
Added country-based romanization

### DIFF
--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -24,3 +24,8 @@ tqdm==2.2.3
 tzdata
 zstd==1.5.7.3
 pycountry==26.2.16
+cutlet
+unidic-lite
+pypinyin
+koroman==1.0.14
+arabic_buckwalter_transliteration

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -23,4 +23,4 @@ qasync==0.27.1
 tqdm==2.2.3
 tzdata
 zstd==1.5.7.3
-countryflag==1.1.1
+pycountry==26.2.16

--- a/src/Helpers/TSHCountryHelper.py
+++ b/src/Helpers/TSHCountryHelper.py
@@ -19,8 +19,7 @@ from ..TournamentDataProvider import TournamentDataProvider
 from .TSHLocaleHelper import TSHLocaleHelper
 import orjson
 from loguru import logger
-import countryflag
-from countryflag.core.exceptions import InvalidCountryError
+import pycountry
 
 
 class TSHCountryHelperSignals(QObject):
@@ -92,9 +91,10 @@ class TSHCountryHelper(QObject):
         }
     
         try:
-            data["emoji"] = countryflag.getflag(TSHCountryHelper.countries[country_code]["code"])
-        except InvalidCountryError:
-            # logger.warning(f'The following country could not be found in the countryflag library: {TSHCountryHelper.countries[country_code]["code"]}')
+            country = pycountry.countries.get(alpha_2=TSHCountryHelper.countries[country_code]["code"])
+            data["emoji"] = country.flag
+        except AttributeError:
+            logger.warning(f'The following country could not be found in the pycountry library: {TSHCountryHelper.countries[country_code]["code"]}')
             data["emoji"] = None
         
         return data

--- a/src/Helpers/TSHLocaleHelper.py
+++ b/src/Helpers/TSHLocaleHelper.py
@@ -11,6 +11,12 @@ from src.StateManager import StateManager
 from .TSHDictHelper import deep_clone
 from .TSHDirHelper import TSHResolve
 
+# Import romanizers
+import cutlet
+from pypinyin import pinyin
+import koroman
+from arabic_buckwalter_transliteration.transliteration import arabic_to_buckwalter
+
 
 class TSHLocaleHelperSignals(QObject):
     localeChanged = Signal()
@@ -105,6 +111,24 @@ class TSHLocaleHelper(QObject):
 
     def GetCountryContinent(countryCode2: str):
         return TSHLocaleHelper.countryToContinent.get(countryCode2.upper(), "")
+
+    def RomanizeTextFromCountry(text, countryCode2: str):
+        romanized_text = text
+        if romanized_text:
+            languages = TSHLocaleHelper.GetCountrySpokenLanguages(countryCode2)
+            if "ja" in languages:
+                katsu = cutlet.Cutlet()
+                romanized_text = katsu.romaji(text)
+            elif "zh" in languages:
+                pinyin_text = pinyin(text)
+                romanized_text = ""
+                for pinyin_character in pinyin_text:
+                    romanized_text = romanized_text + pinyin_character[0]
+            elif "ko" in languages:
+                romanized_text = koroman.romanize(text)
+            elif "ar" in languages:
+                romanized_text = arabic_to_buckwalter(text)
+        return(romanized_text)
 
     def LoadRoundNames():
         # Load default round names and translation
@@ -210,7 +234,6 @@ class TSHLocaleHelper(QObject):
             except:
                 logger.error(
                     f"Unable to generate match strings for {matchString}")
-
-
+    
 TSHLocaleHelper.LoadLanguages()
 TSHLocaleHelper.LoadCountryToLanguage()

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -17,6 +17,7 @@ from .Workers import Worker
 import threading
 from .Helpers.TSHBadWordFilter import TSHBadWordFilter
 from .Helpers.TSHCustomPlayerCompleter import TSHCustomPlayerCompleter
+from .Helpers.TSHLocaleHelper import TSHLocaleHelper
 from loguru import logger
 
 
@@ -269,6 +270,8 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                 self.ExportPlayerId()
 
             self.lastExportedName = merged
+
+            self.SetRomanizedText()
 
     def ExportMergedName(self):
         with self.dataLock:
@@ -632,6 +635,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             country.lineEdit().setFont(QFont(country.font().family(), 9))
 
             country.currentIndexChanged.connect(self.LoadStates)
+            country.currentIndexChanged.connect(self.SetRomanizedText)
 
             state: QComboBox = self.findChild(QComboBox, "state")
             state.completer().setFilterMode(Qt.MatchFlag.MatchContains)
@@ -1037,3 +1041,17 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                 else:
                     c.setCurrentIndex(0)
         StateManager.ReleaseSaving()
+
+    def SetRomanizedText(self):
+        name = self.findChild(QWidget, "name").text()
+        team = self.findChild(QWidget, "team").text()
+        romanized_data = {"name": name, "team": team}
+        country = self.findChild(QComboBox, "country")
+        if country.currentData(Qt.ItemDataRole.UserRole) != None:
+            country_code = country.currentData(Qt.ItemDataRole.UserRole).get("code")
+            if country_code:
+                romanized_data = {
+                    "name": TSHLocaleHelper.RomanizeTextFromCountry(name, country_code),
+                    "team": TSHLocaleHelper.RomanizeTextFromCountry(team, country_code)
+                }
+        StateManager.Set(f"{self.path}.romanized_data", romanized_data)


### PR DESCRIPTION
- Added country-based romanization
  - If a country is set for the player, the program will try to use that data to provide romanized versions of the tag and team data
  - Current support:
    - Japanese (via `cutlet`)
    - Chinese (via `pypinyin`)
    - Korean (via `koroman`)
    - Arabic (via `arabic_buckwalter_transliteration`)
- Replace countryflag library by pycountry