### PR TITLE
do not alphabetize preset colours

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -1119,7 +1119,6 @@ class TSHGameAssetManager(QObject):
                 item.setData(data, Qt.ItemDataRole.UserRole)
                 self.colorModel.appendRow(item)
 
-            self.colorModel.sort(0)
         except:
             logger.error(traceback.format_exc())
 


### PR DESCRIPTION
Seems unintentional given that the Melee config has Computer Player at the bottom, but it shows up at the top
<img width="408" height="715" alt="image" src="https://github.com/user-attachments/assets/35ec4be7-0691-49bb-bb20-12ca16d88ce6" />
<img width="255" height="236" alt="image" src="https://github.com/user-attachments/assets/9de5c19b-2ab4-4cab-bebb-91c202f3f095" />
