### PR TITLE
Many fixes, details on PR description

### DIFF
--- a/src/SettingsManager.py
+++ b/src/SettingsManager.py
@@ -5,17 +5,22 @@ from .Helpers.TSHDictHelper import *
 
 class SettingsManager:
     settings = {}
+    load_error: "str | None" = None
 
     def SaveSettings():
         with open("./user_data/settings.json", 'wb') as file:
-            file.write(orjson.dumps(SettingsManager.settings, option=orjson.OPT_NON_STR_KEYS))
+            file.write(orjson.dumps(SettingsManager.settings, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2))
 
     def LoadSettings():
+        SettingsManager.load_error = None
         try:
             with open("./user_data/settings.json", 'rb') as file:
                 SettingsManager.settings = orjson.loads(file.read())
-        except:
+        except FileNotFoundError:
             SettingsManager.settings = {}
+        except Exception as e:
+            SettingsManager.settings = {}
+            SettingsManager.load_error = f"./user_data/settings.json\n\n{e}"
 
     def Set(key: str, value):
         deep_set(SettingsManager.settings, key, value)

--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -28,6 +28,7 @@ class StateManager:
     signals = StateManagerSignals()
     changedKeys = []
     deltaIndex = 0
+    load_error: "str | None" = None
 
     lock = threading.RLock()
     threads = []
@@ -128,6 +129,7 @@ class StateManager:
                         t.join()
 
     def LoadState():
+        StateManager.load_error = None
         try:
             with open("./out/program_state.json", 'rb') as file:
                 StateManager.state = orjson.loads(file.read())
@@ -136,6 +138,7 @@ class StateManager:
             pass
         except Exception as e:
             logger.error(traceback.format_exc())
+            StateManager.load_error = f"./out/program_state.json\n\n{e}"
             StateManager.state = {}
             StateManager.signals.state_big_change.emit()
             StateManager.SaveState()

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -19,6 +19,7 @@ import requests
 class TSHGameAssetManagerSignals(QObject):
     onLoad = Signal()
     onLoadAssets = Signal()
+    json_error = Signal(str, str)  # title, detail
 
 
 class TSHGameAssetManager(QObject):
@@ -96,9 +97,17 @@ class TSHGameAssetManager(QObject):
 
                     for game in gameDirs:
                         if os.path.isfile("./user_data/games/"+game+"/base_files/config.json"):
-                            with open("./user_data/games/"+game +
-                                      "/base_files/config.json", "rb") as f:
-                                self.parent().games[game] = orjson.loads(f.read())
+                            path = f"./user_data/games/{game}/base_files/config.json"
+                            with open(path, "rb") as f:
+                                try:
+                                    self.parent().games[game] = orjson.loads(f.read())
+                                except Exception as e:
+                                    logger.error(f"JSON error in {path}: {e}")
+                                    self.parent().signals.json_error.emit(
+                                        QApplication.translate("app", "Invalid JSON file"),
+                                        f"{path}\n\n{e}",
+                                    )
+                                    continue
 
                             # Try logo_small, if it doesn't exist use logo
                             # Store path only — QPixmap/QIcon must be created on the main thread
@@ -122,10 +131,17 @@ class TSHGameAssetManager(QObject):
                                     if os.path.isfile("./user_data/games/"+game+"/"+dir+"/config.json"):
                                         logger.info(
                                             "Found asset config for ["+game+"]["+dir+"]")
-                                        with open("./user_data/games/"+game+"/"+dir +
-                                                  "/config.json", "rb") as f:
-                                            self.parent().games[game]["assets"][dir] = \
-                                                orjson.loads(f.read())
+                                        asset_path = f"./user_data/games/{game}/{dir}/config.json"
+                                        with open(asset_path, "rb") as f:
+                                            try:
+                                                self.parent().games[game]["assets"][dir] = \
+                                                    orjson.loads(f.read())
+                                            except Exception as e:
+                                                logger.error(f"JSON error in {asset_path}: {e}")
+                                                self.parent().signals.json_error.emit(
+                                                    QApplication.translate("app", "Invalid JSON file"),
+                                                    f"{asset_path}\n\n{e}",
+                                                )
                                     else:
                                         logger.warning(
                                             "No config file for "+game+" - "+dir)
@@ -145,6 +161,21 @@ class TSHGameAssetManager(QObject):
                                 if game_name:
                                     self.parent(
                                     ).games[game]["name"] = game_name
+
+                            # Add alternate versions as separate selectable game entries
+                            for alt_idx, alt in enumerate(self.parent().games[game].get("alternate_versions", [])):
+                                alt_key = f"{game}__alt_{alt_idx}"
+                                alt_entry = dict(self.parent().games[game])
+                                alt_entry.update(alt)
+                                alt_entry["base_game_dir"] = game
+                                alt_entry["mods_active_default"] = True
+                                alt_entry["alternate_versions"] = []  # avoid recursive expansion
+                                alt_logo_file = alt.get("logo_path", "")
+                                if alt_logo_file:
+                                    alt_logo_path = f"./user_data/games/{game}/base_files/{alt_logo_file}"
+                                    alt_entry["logo_path"] = alt_logo_path if os.path.isfile(alt_logo_path) \
+                                        else self.parent().games[game].get("logo_path")
+                                self.parent().games[alt_key] = alt_entry
                         else:
                             logger.info("Game config for "+game+" doesn't exist.")
                     # print(self.parent().games)
@@ -154,44 +185,20 @@ class TSHGameAssetManager(QObject):
         gameLoaderThread.start()
 
     def SetGameFromStartGGId(self, gameid):
-        def detect_smashgg_id_match(game, id):
-            result = str(game.get("smashgg_game_id", "")) == str(id)
-            if not result:
-                alternates = game.get("alternate_versions", [])
-                alternates_ids = []
-                for alternate in alternates:
-                    if alternate.get("smashgg_game_id"):
-                        alternates_ids.append(
-                            str(alternate.get("smashgg_game_id")))
-                result = str(id) in alternates_ids
-            return (result)
-
         if len(self.games.keys()) == 0:
             return
 
         for i, game in enumerate(self.games.values()):
-            if detect_smashgg_id_match(game, gameid):
+            if str(game.get("smashgg_game_id", "")) == str(gameid):
                 self.LoadGameAssets(i+1)
                 break
-    
-    def SetGameFromIGDBId(self, igdb_id):
-        def detect_igdb_id_match(game, igdb_id):
-            result = str(game.get("igdb_game_id", "")) == str(igdb_id)
-            if not result:
-                alternates = game.get("alternate_versions", [])
-                alternate_ids = []
-                for alternate in alternates:
-                    if alternate.get("igdb_game_id"):
-                        alternate_ids.append(
-                            str(alternate.get("igdb_game_id")))
-                result = str(igdb_id) in alternate_ids
-            return (result)
 
+    def SetGameFromIGDBId(self, igdb_id):
         if len(self.games.keys()) == 0:
             return
 
         for i, game in enumerate(self.games.values()):
-            if detect_igdb_id_match(game, igdb_id):
+            if str(game.get("igdb_game_id", "")) == str(igdb_id):
                 self.LoadGameAssets(i+1)
                 break
 
@@ -252,6 +259,11 @@ class TSHGameAssetManager(QObject):
                     else:
                         game = list(self.parent().games.keys())[game-1]
 
+                    _game_meta = self.parent().games.get(game, {})
+                    game_dir = _game_meta.get("base_game_dir", game)
+                    if _game_meta.get("mods_active_default") and not self.mods_active:
+                        self.mods_active = True
+
                     # Game is already loaded
                     if game == self.parent().selectedGame.get("codename") and (not self.mods_reload_mode):
                         self.parent().threadpool.waitForDone()
@@ -259,7 +271,7 @@ class TSHGameAssetManager(QObject):
 
                     logger.info("Changed to game: "+game)
 
-                    self.parent().CopyCSS(game)
+                    self.parent().CopyCSS(game_dir)
 
                     gameObj = self.parent().games.get(game, {})
                     self.parent().selectedGame = gameObj
@@ -283,7 +295,7 @@ class TSHGameAssetManager(QObject):
                         assetsObj = gameObj.get(
                             "assets", {}).get(assetsKey, None)
                         files = sorted(os.listdir(
-                            './user_data/games/'+game+'/'+assetsKey))
+                            './user_data/games/'+game_dir+'/'+assetsKey))
 
                         self.parent().stockIcons = {}
 
@@ -310,7 +322,7 @@ class TSHGameAssetManager(QObject):
                                     pass
                                 # Store path only — QImage must be created on the main thread
                                 self.parent().stockIcons[c][number] = \
-                                    './user_data/games/'+game+'/'+assetsKey+'/'+f
+                                    './user_data/games/'+game_dir+'/'+assetsKey+'/'+f
 
                         logger.info("Loaded stock icons")
 
@@ -327,7 +339,7 @@ class TSHGameAssetManager(QObject):
                                 asset = gameObj["assets"][assetsKey]
 
                                 files = sorted(os.listdir(
-                                    './user_data/games/'+game+'/'+assetsKey))
+                                    './user_data/games/'+game_dir+'/'+assetsKey))
 
                                 filteredFiles = \
                                     [f for f in files if f.startswith(asset.get(
@@ -411,10 +423,10 @@ class TSHGameAssetManager(QObject):
                             assetsObj = gameObj.get(
                                 "assets", {}).get(assetsKey)
                             files = sorted(os.listdir(
-                                './user_data/games/'+game+'/'+assetsKey))
+                                './user_data/games/'+game_dir+'/'+assetsKey))
 
                             for stage in self.parent().stages:
-                                self.parent().stages[stage]["path"] = './user_data/games/'+game+'/'+assetsKey+'/'+assetsObj.get(
+                                self.parent().stages[stage]["path"] = './user_data/games/'+game_dir+'/'+assetsKey+'/'+assetsObj.get(
                                     "prefix", "")+self.parent().stages[stage].get("codename", "")+assetsObj.get("postfix", "")+".png"
 
                         for s in self.parent().stages.keys():
@@ -584,13 +596,18 @@ class TSHGameAssetManager(QObject):
                     else:
                         game = list(self.parent.games.keys())[game-1]
 
+                    _game_meta = self.parent.games.get(game, {})
+                    game_dir = _game_meta.get("base_game_dir", game)
+                    if _game_meta.get("mods_active_default") and not mods_active:
+                        mods_active = True
+
                     # Game is already loaded
                     if game == self.parent.selectedGame.get("codename") and (not mods_reload_mode):
                         return
 
                     logger.info("Changed to game: "+game)
 
-                    self.parent.CopyCSS(game)
+                    self.parent.CopyCSS(game_dir)
 
                     gameObj = self.parent.games.get(game, {})
                     self.parent.selectedGame = gameObj
@@ -614,7 +631,7 @@ class TSHGameAssetManager(QObject):
                         assetsObj = gameObj.get(
                             "assets", {}).get(assetsKey, None)
                         files = sorted(os.listdir(
-                            './user_data/games/'+game+'/'+assetsKey))
+                            './user_data/games/'+game_dir+'/'+assetsKey))
 
                         self.parent.stockIcons = {}
 
@@ -641,7 +658,7 @@ class TSHGameAssetManager(QObject):
                                     pass
                                 # Store path only — QImage must be created on the main thread
                                 self.parent.stockIcons[c][number] = \
-                                    './user_data/games/'+game+'/'+assetsKey+'/'+f
+                                    './user_data/games/'+game_dir+'/'+assetsKey+'/'+f
 
                         logger.info("Loaded stock icons")
 
@@ -658,7 +675,7 @@ class TSHGameAssetManager(QObject):
                                 asset = gameObj["assets"][assetsKey]
 
                                 files = sorted(os.listdir(
-                                    './user_data/games/'+game+'/'+assetsKey))
+                                    './user_data/games/'+game_dir+'/'+assetsKey))
 
                                 filteredFiles = \
                                     [f for f in files if f.startswith(asset.get(
@@ -742,10 +759,10 @@ class TSHGameAssetManager(QObject):
                             assetsObj = gameObj.get(
                                 "assets", {}).get(assetsKey)
                             files = sorted(os.listdir(
-                                './user_data/games/'+game+'/'+assetsKey))
+                                './user_data/games/'+game_dir+'/'+assetsKey))
 
                             for stage in self.parent.stages:
-                                self.parent.stages[stage]["path"] = './user_data/games/'+game+'/'+assetsKey+'/'+assetsObj.get(
+                                self.parent.stages[stage]["path"] = './user_data/games/'+game_dir+'/'+assetsKey+'/'+assetsObj.get(
                                     "prefix", "")+self.parent.stages[stage].get("codename", "")+assetsObj.get("postfix", "")+".png"
 
                         for s in self.parent.stages.keys():
@@ -902,8 +919,15 @@ class TSHGameAssetManager(QObject):
             self.assetsLoader.run(mods_active=mods_active, mods_reload_mode=mods_reload_mode)
 
         # Setup startgg character id to character name
-        sggcharacters = orjson.loads(
-            open('./assets/characters.json', 'rb').read())
+        try:
+            sggcharacters = orjson.loads(open('./assets/characters.json', 'rb').read())
+        except Exception as e:
+            logger.error(f"JSON error in ./assets/characters.json: {e}")
+            self.signals.json_error.emit(
+                QApplication.translate("app", "Invalid JSON file"),
+                f"./assets/characters.json\n\n{e}",
+            )
+            sggcharacters = {}
         self.startgg_id_to_character = {}
 
         for c in sggcharacters.get("entities", {}).get("character", []):
@@ -1175,7 +1199,15 @@ class TSHGameAssetManager(QObject):
         icon_config_path = f"{asset_root_path}/{game_codename}/variant_icon/config.json"
         if os.path.isfile(icon_config_path):
             with open(icon_config_path, "rt", encoding="utf-8") as icon_config_file:
-                icon_config = orjson.loads(icon_config_file.read())
+                try:
+                    icon_config = orjson.loads(icon_config_file.read())
+                except Exception as e:
+                    logger.error(f"JSON error in {icon_config_path}: {e}")
+                    self.signals.json_error.emit(
+                        QApplication.translate("app", "Invalid JSON file"),
+                        f"{icon_config_path}\n\n{e}",
+                    )
+                    return icon_path
             extensions = ["png", "jpg", "gif", "webp"]
             for extension in extensions:
                 icon_filename = f"{asset_root_path}/{game_codename}/variant_icon/{icon_config.get('prefix')}{variant_codename}{icon_config.get('postfix')}.{extension}"
@@ -1183,14 +1215,22 @@ class TSHGameAssetManager(QObject):
                     icon_path = icon_filename
                     break
         return(icon_path)
-    
+
     def GetVariantIconSize(self, variant_codename):
         game_codename = self.selectedGame.get("codename")
         icon_size, asset_root_path = None, "./user_data/games"
         icon_config_path = f"{asset_root_path}/{game_codename}/variant_icon/config.json"
         if os.path.isfile(icon_config_path):
             with open(icon_config_path, "rt", encoding="utf-8") as icon_config_file:
-                icon_config = orjson.loads(icon_config_file.read())
+                try:
+                    icon_config = orjson.loads(icon_config_file.read())
+                except Exception as e:
+                    logger.error(f"JSON error in {icon_config_path}: {e}")
+                    self.signals.json_error.emit(
+                        QApplication.translate("app", "Invalid JSON file"),
+                        f"{icon_config_path}\n\n{e}",
+                    )
+                    return icon_size
             icon_filename = f"{asset_root_path}/{game_codename}/variant_icon/{icon_config.get('prefix')}{variant_codename}{icon_config.get('postfix')}.png"
             if os.path.isfile(icon_filename):
                 icon_size = icon_config.get("image_sizes", {}).get(variant_codename, {}).get("null")

--- a/src/TSHIndividualGameTracker.py
+++ b/src/TSHIndividualGameTracker.py
@@ -237,8 +237,8 @@ class TSHIndividualGameTracker(QWidget):
             existing.pop(char_slot + 1, None)
         StateManager.Set(path, existing)
 
-        # Sync to main selector if this is the current (last) game
-        if game_idx == len(self.stage_widget_list) - 1 and not self._syncing_chars:
+        # Sync to main selector if this is the current game (first without a result)
+        if game_idx == self._GetCurrentGameIdx() and not self._syncing_chars:
             self._syncing_chars = True
             try:
                 self.signals.syncCharToMain.emit(team, player, char_slot, data)
@@ -253,10 +253,19 @@ class TSHIndividualGameTracker(QWidget):
             if lbl:
                 lbl.setText(display)
 
-    def SetStageCount(self, stage_count=0):
-        """Resets the game tracker completely and starts with a single row. Called on new set / game asset load."""
+    def SetStageCount(self, stage_count=0, carry_stage_codename=None):
+        """Resets the game tracker completely. Called on new set / game asset load."""
 
-        self._layout.removeWidget(self.stage_order_list_widget)
+        # If not pre-computed by caller (before score changes), derive it now
+        if carry_stage_codename is None:
+            current_idx = self._GetCurrentGameIdx()
+            saved_stage = StateManager.Get(f"score.{self.scoreboard_number}.stages.{current_idx+1}", {})
+            carry_stage_codename = saved_stage.get("codename") if isinstance(saved_stage, dict) else None
+
+        old = self.stage_order_list_widget
+        self._layout.removeWidget(old)
+        old.setParent(None)
+        old.deleteLater()
         self.stage_widget_list = []
         self.stage_order_list_layout = QVBoxLayout()
         self.stage_order_list_widget = QWidget()
@@ -267,20 +276,34 @@ class TSHIndividualGameTracker(QWidget):
             self.setVisible(False)
         else:
             self.setVisible(True)
-            self._AddGameRow()
+            count = stage_count if stage_count > 0 else 1
+            for i in range(count):
+                self._AddGameRow(copy_chars=(i == 0))
         self._layout.addWidget(self.stage_order_list_widget)
+        if carry_stage_codename and self.isVisible() and self.stage_widget_list:
+            combo: QComboBox = self.stage_widget_list[0].findChild(QComboBox, "stageMenu_0")
+            if combo is not None:
+                model = combo.model()
+                for i in range(1, model.rowCount()):
+                    item_data = model.item(i).data(Qt.ItemDataRole.UserRole)
+                    if isinstance(item_data, dict) and item_data.get("codename") == carry_stage_codename:
+                        combo.setCurrentIndex(i)
+                        break
 
     def UpdateBestOf(self, stage_count=0):
-        """Updates the best-of cap without resetting rows. Called when the spinbox changes."""
+        """Updates the best-of and expands rows to show all games. Called when the spinbox changes."""
         self.best_of = stage_count
+        if self.isVisible():
+            self._EnsureCorrectRowCount()
 
-    def _AddGameRow(self):
-        """Appends one new game row to the tracker, pre-filled with current set-level characters."""
+    def _AddGameRow(self, copy_chars=True):
+        """Appends one new game row to the tracker."""
         idx = len(self.stage_widget_list)
         widget = self.CreateStage(idx)
         self.stage_widget_list.append(widget)
         self.stage_order_list_layout.addWidget(widget)
-        self._CopySetLevelCharactersToGame(idx)
+        if copy_chars:
+            self._CopySetLevelCharactersToGame(idx)
 
     def _RemoveLastRow(self):
         """Removes the last game row and clears its state."""
@@ -293,26 +316,33 @@ class TSHIndividualGameTracker(QWidget):
         StateManager.Unset(f"score.{self.scoreboard_number}.stages.{idx+1}")
         self._SyncLastStageToStrike()
 
+    def _GetCurrentGameIdx(self):
+        """Returns the index of the first game with no result (the 'current' game being played)."""
+        for i in range(len(self.stage_widget_list)):
+            if self._get_game_winner(i) == -1:
+                return i
+        return len(self.stage_widget_list) - 1
+
     def _EnsureCorrectRowCount(self):
-        """Trims excess trailing empty rows (keeps exactly 1), then adds one if all rows have results."""
+        """Maintains the correct number of rows based on best_of and current results."""
         if not self.stage_widget_list:
             return
 
-        # Trim trailing rows with no result, keeping at least 1 empty row at the end
+        if self.best_of > 0:
+            # Always show all best_of rows so stages can be pre-set before the set starts
+            while len(self.stage_widget_list) < self.best_of:
+                self._AddGameRow(copy_chars=False)
+            while len(self.stage_widget_list) > self.best_of:
+                self._RemoveLastRow()
+            return
+
+        # best_of == 0: dynamic behavior — keep exactly 1 trailing empty row
         while len(self.stage_widget_list) > 1 and self._get_game_winner(len(self.stage_widget_list) - 1) == -1:
-            # Second-to-last row also empty? Remove the last row.
             if self._get_game_winner(len(self.stage_widget_list) - 2) == -1:
                 self._RemoveLastRow()
             else:
                 break
 
-        t1_wins = len(self.GetWonStages(0))
-        t2_wins = len(self.GetWonStages(1))
-        wins_needed = math.ceil(self.best_of / 2) if self.best_of > 0 else 999
-        if t1_wins >= wins_needed or t2_wins >= wins_needed:
-            return
-        if self.best_of > 0 and len(self.stage_widget_list) >= self.best_of:
-            return
         all_have_results = all(
             self._get_game_winner(i) != -1
             for i in range(len(self.stage_widget_list))
@@ -588,20 +618,20 @@ class TSHIndividualGameTracker(QWidget):
         StateManager.ReleaseSaving()
 
     def _SyncLastStageToStrike(self):
-        """Reads the new last row's stage combo and syncs it to selectedStage/selectedStageData."""
+        """Reads the current game's stage combo and syncs it to selectedStage/selectedStageData."""
         if not self.stage_widget_list:
             with StateManager.SaveBlock():
                 StateManager.Set(f"score.{self.scoreboard_number}.stage_strike.selectedStage", None)
                 StateManager.Set(f"score.{self.scoreboard_number}.stage_strike.selectedStageData", None)
             return
-        last = len(self.stage_widget_list) - 1
-        combo = self.findChild(QComboBox, f"stageMenu_{last}")
+        current = self._GetCurrentGameIdx()
+        combo = self.findChild(QComboBox, f"stageMenu_{current}")
         if combo is not None:
-            self._SyncStageToStrike(last, combo.currentData() or {})
+            self._SyncStageToStrike(current, combo.currentData() or {})
 
     def _SyncStageToStrike(self, game_idx, stage_data):
-        """When the last game row's stage changes, push it to stage_strike.selectedStage/selectedStageData."""
-        if game_idx == len(self.stage_widget_list) - 1:
+        """When the current game row's stage changes, push it to stage_strike.selectedStage/selectedStageData."""
+        if game_idx == self._GetCurrentGameIdx():
             codename = stage_data.get("codename") if isinstance(stage_data, dict) else None
             with StateManager.SaveBlock():
                 StateManager.Set(f"score.{self.scoreboard_number}.stage_strike.selectedStage", codename)

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -164,11 +164,12 @@ class TSHPlayerDB:
 
             charIcons = {}
 
-            for char in TSHGameAssetManager.instance.stockIcons:
+            stock_icons = {k: dict(v) for k, v in TSHGameAssetManager.instance.stockIcons.items()}
+            for char, skins in stock_icons.items():
                 charIcons[char] = {}
-                for skin in TSHGameAssetManager.instance.stockIcons[char]:
+                for skin, path in skins.items():
                     charIcons[char][skin] = QIcon(QPixmap.fromImage(
-                        QImage(TSHGameAssetManager.instance.stockIcons[char][skin]).scaledToWidth(
+                        QImage(path).scaledToWidth(
                             32, Qt.TransformationMode.SmoothTransformation)))
 
             for player in TSHPlayerDB.database.values():

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -520,6 +520,10 @@ class TSHScoreboardWidget(QWidget):
                 StateManager.Set(f"score.{self.scoreboardNumber}.first_to_text", TSHLocaleHelper.matchNames.get(
                     "first_to").format(math.ceil(value/2)) if value > 0 else ""),
                 self.individualGameTracker.UpdateBestOf(value),
+                self.scoreColumn.findChild(QSpinBox, "score_left").setMaximum(
+                    math.ceil(value / 2) if value > 0 else 999),
+                self.scoreColumn.findChild(QSpinBox, "score_right").setMaximum(
+                    math.ceil(value / 2) if value > 0 else 999),
                 StateManager.ReleaseSaving()
             ]
         )
@@ -600,12 +604,12 @@ class TSHScoreboardWidget(QWidget):
             StateManager.Set(f"score.{self.scoreboardNumber}.team.2.score", team_2_score)
 
     def _onMainCharChanged(self):
-        """Called when a main-scoreboard character selection changes; copies it to the current (last) game row."""
+        """Called when a main-scoreboard character selection changes; copies it to the current game row."""
         if not hasattr(self, "individualGameTracker"):
             return
-        last = len(self.individualGameTracker.stage_widget_list) - 1
-        if last >= 0:
-            self.individualGameTracker._CopySetLevelCharactersToGame(last)
+        current = self.individualGameTracker._GetCurrentGameIdx()
+        if current >= 0:
+            self.individualGameTracker._CopySetLevelCharactersToGame(current)
 
     def _onSyncCharFromGame(self, team, player, char_slot, char_data):
         """Called when the current game row's character changes; pushes it to the main player widget combo."""
@@ -909,8 +913,17 @@ class TSHScoreboardWidget(QWidget):
             StateManager.ReleaseSaving()
 
     def ResetScore(self):
+        # Capture current game's stage before score zeroing clears the win buttons
+        current_idx = self.individualGameTracker._GetCurrentGameIdx()
+        saved_stage = StateManager.Get(f"score.{self.scoreboardNumber}.stages.{current_idx+1}", {})
+        carry_stage = saved_stage.get("codename") if isinstance(saved_stage, dict) else None
+
         self.scoreColumn.findChild(QSpinBox, "score_left").setValue(0)
         self.scoreColumn.findChild(QSpinBox, "score_right").setValue(0)
+        self.individualGameTracker.SetStageCount(
+            self.scoreColumn.findChild(QSpinBox, "best_of").value(),
+            carry_stage_codename=carry_stage
+        )
 
     def AutoUpdate(self, data):
         TSHTournamentDataProvider.instance.GetMatch(

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -815,6 +815,9 @@ class Window(QMainWindow):
         TSHGameAssetManager.instance.signals.onLoad.connect(
             TSHAssetDownloader.instance.CheckAssetUpdates
         )
+        TSHGameAssetManager.instance.signals.json_error.connect(
+            lambda title, msg: QMessageBox.critical(self, title, msg)
+        )
         TSHAssetDownloader.instance.signals.AssetUpdates.connect(
             self.OnAssetUpdates
         )
@@ -838,10 +841,13 @@ class Window(QMainWindow):
         moddedContentLayout.addWidget(moddedContentCheckLabel)
         moddedContentLayout.addWidget(self.moddedContentCheck)
 
-        TSHGameAssetManager.instance.signals.onLoad.connect(lambda x=None: [
-            self.moddedContentWidget.setVisible(TSHGameAssetManager.instance.has_modded_content),
-            self.moddedContentCheck.setChecked(StateManager.Get("game").get("mods_active", False))
-        ])
+        def _on_game_load():
+            self.moddedContentWidget.setVisible(TSHGameAssetManager.instance.has_modded_content)
+            # Block stateChanged so setting the checkbox programmatically doesn't trigger a reload
+            with QSignalBlocker(self.moddedContentCheck):
+                self.moddedContentCheck.setChecked(StateManager.Get("game").get("mods_active", False))
+
+        TSHGameAssetManager.instance.signals.onLoad.connect(_on_game_load)
 
         self.moddedContentCheck.stateChanged.connect(lambda x=None: [
             print("Checked: "+ str(self.moddedContentCheck.isChecked())),
@@ -854,8 +860,21 @@ class Window(QMainWindow):
         TSHTournamentDataProvider.instance.signals.tournament_changed.connect(
             lambda x=None: self.moddedContentCheck.setChecked(False))
 
+        self.gameReloadBtn = QPushButton()
+        self.gameReloadBtn.setIcon(QApplication.style().standardIcon(QStyle.StandardPixmap.SP_BrowserReload))
+        self.gameReloadBtn.setToolTip(QApplication.translate("app", "Reload game assets"))
+        self.gameReloadBtn.setFixedSize(24, 24)
+        self.gameReloadBtn.clicked.connect(
+            lambda: TSHGameAssetManager.instance.LoadGameAssets(
+                self.gameSelect.currentData(),
+                mods_active=self.moddedContentCheck.isChecked(),
+                mods_reload_mode=True,
+            )
+        )
+
         pre_base_layout.addLayout(base_layout)
         hbox.addWidget(self.gameSelect)
+        hbox.addWidget(self.gameReloadBtn)
         hbox.addWidget(self.moddedContentWidget)
 
         self.scoreboardAmount = QSpinBox()
@@ -900,6 +919,14 @@ class Window(QMainWindow):
 
         splash.finish(self)
         self.show()
+
+        for path_error in [SettingsManager.load_error, StateManager.load_error]:
+            if path_error:
+                QMessageBox.critical(
+                    self,
+                    QApplication.translate("app", "Invalid JSON file"),
+                    path_error,
+                )
 
         TSHCountryHelper.LoadCountries()
         self.settingsWindow.UiMounted()


### PR DESCRIPTION
## Changes

### Individual Game Tracker (`TSHIndividualGameTracker.py`)
- When `best_of` is set, pre-create all N game rows upfront so stages can be pre-set before the set starts
- Added `_GetCurrentGameIdx()` to find the active game (first row with no result)
- New rows beyond game 1 start empty (no characters pre-filled)
- Decreasing `best_of` now removes excess rows from the UI
- `SetStageCount` properly unparents the old widget before replacing it, fixing stale widget visibility after reset
- On reset, the current game's stage is carried forward to game 1 of the new set
- Stage/character sync now targets the current game instead of always the last row

### Scoreboard (`TSHScoreboardWidget.py`)
- Reset score now clears all per-game stage/character data while keeping `best_of`
- Score spinboxes are capped at `ceil(best_of / 2)` when `best_of > 0`
- Fixed character sync from main scoreboard targeting the last row instead of the current game
- Fixed stage carry-over on reset: current game is captured before score zeroing clears win buttons

### Alternate Game Versions (`TSHGameAssetManager.py`)
- `alternate_versions` entries in `config.json` now appear as separate selectable games in the game list (e.g. "Smash Remix" alongside SSB64)
- Selecting an alternate version auto-enables modded content
- Alternate versions are correctly auto-selected when detected from the tournament API
- JSON parse errors in game config files now emit a signal with the file path and error details

### UI (`TournamentStreamHelper.py`)
- Added a reload button next to the game selector to force-reload assets (clears cache)
- Error dialogs shown on startup if `settings.json` or `program_state.json` failed to parse
- Error dialogs shown when any game JSON file fails to parse, pointing to the broken file
- Fixed modded content checkbox triggering a redundant asset reload when set programmatically

### Settings & State (`SettingsManager.py`, `StateManager.py`)
- `settings.json` is now saved with indentation (human-readable)
- JSON load errors are stored and shown as dialogs on startup

### Player DB (`TSHPlayerDB.py`)
- Fixed crash (`KeyError`) when game assets reload while the player database model is being built (race condition on `stockIcons`)
